### PR TITLE
Adding a RIG file for VISTA simulator from VISTA-6S191

### DIFF
--- a/examples/resources/RIG.xml
+++ b/examples/resources/RIG.xml
@@ -2,7 +2,7 @@
 <DRIVEWORKS ver="1.0">
    <VEHICLE> <!-- Not used -->
       <PROPERTY Name="Height" Value="1.455"/>
-      <PROPERTY Name="Length" Value="4.915"/>Z
+      <PROPERTY Name="Length" Value="4.915"/>
       <PROPERTY Name="Width" Value="1.874"/>
       <PROPERTY Name="Wheelbase" Value="2.912"/>
       <PROPERTY Name="Front axlebase" Value="1.627"/>

--- a/examples/resources/RIG.xml
+++ b/examples/resources/RIG.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<DRIVEWORKS ver="1.0">
+   <VEHICLE> <!-- Not used -->
+      <PROPERTY Name="Height" Value="1.455"/>
+      <PROPERTY Name="Length" Value="4.915"/>Z
+      <PROPERTY Name="Width" Value="1.874"/>
+      <PROPERTY Name="Wheelbase" Value="2.912"/>
+      <PROPERTY Name="Front axlebase" Value="1.627"/>
+      <PROPERTY Name="Rear axlebase" Value="1.618"/>
+      <PROPERTY Name="Wheel diameter" Value="0.68"/>
+      <PROPERTY Name="Distance axle to rear bumper" Value="1.1091"/>
+      <PROPERTY Name="Distance axle to front bumper" Value="0.912"/>
+      <PROPERTY Name="Steering coefficient" Value="14.8"/>
+   </VEHICLE>
+
+ <SENSORS>
+   <CAMERA Name="camera_front" Type="gmsl">
+      <PROPERTY Name="Model" Value="pinhole"/>
+      <PROPERTY Name="Quaternion" Value="0.0 0.0 -0.0436194 0.9990482"/>
+      <PROPERTY Name="Position" Value="0 1.7653 0"/>
+      <PROPERTY Name="Yaw" Value="0.04"/>
+      <PROPERTY Name="params" Value=""/>
+      <PROPERTY Name="width" Hint="intrinsic" Value="960"/>
+      <PROPERTY Name="height" Hint="intrinsic" Value="600"/>
+      <PROPERTY Name="distortion" Hint="intrinsic" Value="0.005718 -0.001268 -0.000740 -0.001460 0.000000"/>
+      <PROPERTY Name="cx" Hint="intrinsic" Value="498.437823"/>
+      <PROPERTY Name="cy" Hint="intrinsic" Value="285.741420"/>
+      <PROPERTY Name="fx" Hint="intrinsic" Value="262.242074"/>
+      <PROPERTY Name="fy" Hint="intrinsic" Value="261.700119"/>
+      <PROPERTY Name="roi" Hint="region_of_interest" Value="270 264 405 729"/>
+      <PROPERTY Name="roi_angle" Hint="angle of ROI" Value="0"/>
+   </CAMERA>
+
+   <CAMERA Name="event_camera_front" Type="gmsl">
+      <PROPERTY Name="Model" Value="pinhole"/>
+      <PROPERTY Name="Quaternion" Value="0 0 -0.035265025029250387 0.9996807883070832"/> <!-- Inaccurate -->
+      <PROPERTY Name="Position" Value="0 1.65 0"/> <!-- Inaccurate -->
+      <PROPERTY Name="Yaw" Value="0.04"/> <!-- Inaccurate -->
+      <PROPERTY Name="params" Value=""/>
+      <PROPERTY Name="width" Hint="intrinsic" Value="640"/>
+      <PROPERTY Name="height" Hint="intrinsic" Value="480"/>
+      <PROPERTY Name="distortion" Hint="intrinsic" Value="-0.049791099994929616 -0.26611070539342135 -0.0010742618721939665 -0.00084781898284127242 0.90995535712595266"/>
+      <PROPERTY Name="cx" Hint="intrinsic" Value="327.77416522493661"/>
+      <PROPERTY Name="cy" Hint="intrinsic" Value="224.97549602762447"/>
+      <PROPERTY Name="fx" Hint="intrinsic" Value="551.89434037318449"/>
+      <PROPERTY Name="fy" Hint="intrinsic" Value="551.93346045671683"/>
+      <PROPERTY Name="roi" Hint="region_of_interest" Value="216 0 480 640"/>
+      <PROPERTY Name="roi_angle" Hint="angle of ROI" Value="0"/>
+   </CAMERA>
+ </SENSORS>
+
+ <SYNTHESIS>
+   <CAMERA Name="camera_front" Type="gmsl">
+        <PROPERTY Name="Model" Value="pinhole"/>
+        <PROPERTY Name="Quaternion" Value="0.0 0.0 -0.0436194 0.9990482"/>
+        <PROPERTY Name="Position" Value="0 1.7653 0"/>
+        <PROPERTY Name="Yaw" Value="0.04"/>
+        <PROPERTY Name="params" Value=""/>
+        <PROPERTY Name="width" Hint="intrinsic" Value="960"/>
+        <PROPERTY Name="height" Hint="intrinsic" Value="600"/>
+        <PROPERTY Name="distortion" Hint="intrinsic" Value="0.005718 -0.001268 -0.000740 -0.001460 0.000000"/>
+        <PROPERTY Name="cx" Hint="intrinsic" Value="498.437823"/>
+        <PROPERTY Name="cy" Hint="intrinsic" Value="285.741420"/>
+        <PROPERTY Name="fx" Hint="intrinsic" Value="262.242074"/>
+        <PROPERTY Name="fy" Hint="intrinsic" Value="261.700119"/>
+        <PROPERTY Name="roi" Hint="region_of_interest" Value="270 264 405 729"/>
+        <PROPERTY Name="roi_angle" Hint="angle of ROI" Value="0"/>
+   </CAMERA>
+
+   <CAMERA Name="event_camera_front" Type="gmsl">
+      <PROPERTY Name="Model" Value="pinhole"/>
+      <PROPERTY Name="Quaternion" Value="0 0 -0.035265025029250387 0.9996807883070832"/> <!-- Inaccurate -->
+      <PROPERTY Name="Position" Value="0 1.65 0"/> <!-- Inaccurate -->
+      <PROPERTY Name="Yaw" Value="0.04"/> <!-- Inaccurate -->
+      <PROPERTY Name="params" Value=""/>
+      <PROPERTY Name="width" Hint="intrinsic" Value="640"/>
+      <PROPERTY Name="height" Hint="intrinsic" Value="480"/>
+      <PROPERTY Name="distortion" Hint="intrinsic" Value="-0.049791099994929616 -0.26611070539342135 -0.0010742618721939665 -0.00084781898284127242 0.90995535712595266"/>
+      <PROPERTY Name="cx" Hint="intrinsic" Value="327.77416522493661"/>
+      <PROPERTY Name="cy" Hint="intrinsic" Value="224.97549602762447"/>
+      <PROPERTY Name="fx" Hint="intrinsic" Value="551.89434037318449"/>
+      <PROPERTY Name="fy" Hint="intrinsic" Value="551.93346045671683"/>
+      <PROPERTY Name="roi" Hint="region_of_interest" Value="216 0 480 640"/>
+      <PROPERTY Name="roi_angle" Hint="angle of ROI" Value="0"/>
+   </CAMERA>
+ </SYNTHESIS>
+
+ <CALIBRATION>
+  <EXTRINSIC_CAMERA/>
+ </CALIBRATION>
+</DRIVEWORKS>


### PR DESCRIPTION
Hi there,

I have added the RIG.xml file from the repository [VISTA-6S191](https://github.com/vista-simulator/vista-6s191) to help the newcomers to the VISTA community can start the example of the program faster without looking for the RIG file for front-camera.